### PR TITLE
fix: Added vs-icons as a dependency of swipe rather than a direct import

### DIFF
--- a/packages/VSSwipe/index.js
+++ b/packages/VSSwipe/index.js
@@ -7,7 +7,7 @@ import {
   ScrollView,
 } from 'react-native';
 
-import { CircleFillIcon } from '../VSSvg/index';
+import { CircleFillIcon } from '@vivintsolar-oss/native-vs-icons';
 import Indicator from './Indicator';
 
 export default class VSSwipe extends Component {

--- a/packages/VSSwipe/package.json
+++ b/packages/VSSwipe/package.json
@@ -11,6 +11,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@vivintsolar-oss/native-vs-icons": "^1.2.1",
     "react-native-svg": "^6.0.0-rc1"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Checklist
- [x] Atomic commits
- [x] Tests adjusted to address changes
- [x] Documentation
- [x] Storybook adjusted to reflect changes (if applicable)
- [x] Reviewed by author
- [x] Ready for review
